### PR TITLE
Replace url attribute with href attribute in button link component

### DIFF
--- a/resources/views/bootstrap-5/button/link.blade.php
+++ b/resources/views/bootstrap-5/button/link.blade.php
@@ -1,12 +1,13 @@
 @php
     $slot = $slot ?? null;
 @endphp
-<a {!! $attributes->merge([
+<a {!! $attributes->except('url')->merge([
     'class' => 'btn' . ($attributes->has('class') ? null : ' btn-primary'),
     'title' => $attributes->has('title')
         ? $attributes->get('title')
         : ($slot ? strip_tags($slot) : null),
     'role' => 'button',
+    'href' => $attributes->get('url'),
 ]) !!}>
     {{ $slot }}
 </a>

--- a/tests/Unit/Buttons/Href/ButtonLinkHrefTest.php
+++ b/tests/Unit/Buttons/Href/ButtonLinkHrefTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Okipa\LaravelFormComponents\Tests\Unit\Buttons\Title;
+
+use Okipa\LaravelFormComponents\Components\Button\Link;
+use Okipa\LaravelFormComponents\Tests\TestCase;
+
+class ButtonLinkHrefTest extends TestCase
+{
+    /** @test */
+    public function it_can_show_button_link_href(): void
+    {
+        $html = $this->renderComponent(Link::class, attributes: ['url' => 'https://example.com']);
+        self::assertStringContainsString('href="https://example.com"', $html);
+        self::assertStringNotContainsString('url="https://example.com"', $html);
+    }
+}


### PR DESCRIPTION
```
<a class="btn btn-outline-primary btn-sm" title="Afficher" role="button" url="https://example.com" target="_blank">
    <i class="fas fa-external-link-square-alt fa-fw"></i>
        Afficher
</a>
```

`x-form::button.link` writes `url` attribute instead of `href` attribute