### PR TITLE
Input file fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this package will be documented in this file.
 
 2022-04-15
 
-* Fixed Bootstrap 4 input file input validation class wrong positioning: `is-valid` and `is-invalid` classes are now added to the `custom-file` div
+* Fixed Bootstrap 4 input file input validation class wrong positioning:
+  * `is-valid` and `is-invalid` classes are now added to the `custom-file` div without addon declaration
+  * `is-valid` and `is-invalid` classes are now added to the `input-group` div with addon declaration
 * Fixed Bootstrap 4 input caption and error message positioning: they are now positioned under input group div in order to be displayed correctly
 
 ## [1.0.5](https://github.com/Okipa/laravel-form-components/compare/1.0.4...1.0.5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this package will be documented in this file.
 
+## [1.0.6](https://github.com/Okipa/laravel-form-components/compare/1.0.5...1.0.6)
+
+2022-04-15
+
+* Fixed Bootstrap 4 input file input validation class wrong positioning: `is-valid` and `is-invalid` classes are now added to the `custom-file` div
+* Fixed Bootstrap 4 input caption and error message positioning: they are now positioned under input group div in order to be displayed correctly
+
 ## [1.0.5](https://github.com/Okipa/laravel-form-components/compare/1.0.4...1.0.5)
 
 2022-03-18
@@ -18,21 +25,21 @@ All notable changes to this package will be documented in this file.
 
 2022-03-17
 
-* Fixed Bootstrap4 file input missing label
-* Transformed Bootstrap4 file input custom label to behave as a placeholder
+* Fixed Bootstrap 4 file input missing label
+* Transformed Bootstrap 4 file input custom label to behave as a placeholder
 
 ## [1.0.2](https://github.com/Okipa/laravel-form-components/compare/1.0.1...1.0.2)
 
 2022-02-23
 
-* Fixed Bootstrap4 file input
-* Fixed Bootstrap4 caption partial
+* Fixed Bootstrap 4 file input
+* Fixed Bootstrap 4 caption partial
 
 ## [1.0.1](https://github.com/Okipa/laravel-form-components/compare/1.0.0...1.0.1)
 
 2022-02-23
 
-* Fixed Bootstrap4 toggle-switch classes
+* Fixed Bootstrap 4 toggle-switch classes
 
 ## [1.0.0](https://github.com/Okipa/laravel-form-components/releases/tag/1.0.0)
 

--- a/resources/views/bootstrap-4/input.blade.php
+++ b/resources/views/bootstrap-4/input.blade.php
@@ -14,7 +14,7 @@
     <div @class(['d-none' => $type === 'hidden', 'form-floating' => $displayFloatingLabel, 'mb-3' => $marginBottom])>
         @if(($prepend || $append) && ! $displayFloatingLabel)
             <x-form::partials.label :id="$id"  class="form-label" :label="$label"/>
-            <div class="input-group">
+            <div @class(['input-group', $validationClass => $type === 'file' && $validationClass])>
         @endif
             @if(! $prepend && ! $append && ! $displayFloatingLabel)
                 <x-form::partials.label :id="$id" class="form-label" :label="$label"/>
@@ -25,7 +25,7 @@
                 </div>
             @endif
             @if($type === 'file')
-                <div @class(['custom-file', $validationClass => (bool) $validationClass])>
+                <div @class(['custom-file', $validationClass => ! $prepend && ! $append && $validationClass])>
             @endif
                 <input {{ $attributes->except('wire')->merge([
                     'wire:model' . $getComponentLivewireModifier() => $isWired && ! $hasComponentNativeLivewireModelBinding() ? ($locale ? $name . '.' . $locale : $name) : null,

--- a/resources/views/bootstrap-4/input.blade.php
+++ b/resources/views/bootstrap-4/input.blade.php
@@ -25,12 +25,12 @@
                 </div>
             @endif
             @if($type === 'file')
-                <div class="custom-file">
+                <div @class(['custom-file', $validationClass => (bool) $validationClass])>
             @endif
                 <input {{ $attributes->except('wire')->merge([
                     'wire:model' . $getComponentLivewireModifier() => $isWired && ! $hasComponentNativeLivewireModelBinding() ? ($locale ? $name . '.' . $locale : $name) : null,
                     'id' => $id,
-                    'class' => ($type === 'file' ? 'custom-file-input' : 'form-control') . ($validationClass ? ' ' . $validationClass : null),
+                    'class' => $type === 'file' ? 'custom-file-input' : 'form-control' . ($validationClass ? ' ' . $validationClass : null),
                     'type' => $type,
                     'name' => $locale ? $name . '[' . $locale . ']' : $name,
                     'placeholder' => $placeholder,
@@ -38,7 +38,7 @@
                     'value' => $isWired ? null : ($value ?? ''),
                     'aria-describedby' => $caption ? $id . '-caption' : null,
                 ]) }}/>
-            @if(! $prepend && ! $append && ($displayFloatingLabel || $type === 'file'))
+            @if($type === 'file' || (! $prepend && ! $append && $displayFloatingLabel))
                 <x-form::partials.label :id="$id"
                                         :class="$type === 'file' ? 'custom-file-label' : 'form-label'"
                                         :label="$type === 'file' ? $placeholder : $label"/>
@@ -51,10 +51,10 @@
                     <x-form::partials.addon :addon="$append"/>
                 </div>
             @endif
-            <x-form::partials.caption :inputId="$id" :caption="$caption"/>
-            <x-form::partials.error-message :message="$errorMessage"/>
         @if(($prepend || $append) && ! $displayFloatingLabel)
             </div>
         @endif
+        <x-form::partials.caption :inputId="$id" :caption="$caption"/>
+        <x-form::partials.error-message :message="$errorMessage"/>
     </div>
 @endforeach

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,6 +56,13 @@ class TestCase extends Orchestra
 
     protected function assertSeeHtmlInOrder(string $html, array $values): void
     {
-        self::assertTrue((new SeeInOrder($html))->matches($values));
+        self::assertThat($values, new SeeInOrder($html));
+    }
+
+    protected function assertDontSeeHtml(string $html, array $values): void
+    {
+        foreach ($values as $value) {
+            self::assertStringNotContainsString((string) $value, $html);
+        }
     }
 }

--- a/tests/Unit/Bootstrap4/Inputs/Addons/InputAddonsTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/Addons/InputAddonsTest.php
@@ -11,11 +11,11 @@ class InputAddonsTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap5
     {
         config()->set('form-components.floating_label', false);
         $html = $this->renderComponent(Input::class, ['name' => 'first_name', 'prepend' => 'Test prepend']);
-        self::assertStringContainsString('<div class="input-group-prepend">', $html);
-        self::assertStringContainsString('<span class="input-group-text">Test prepend</span>', $html);
-        $addonPosition = strrpos($html, 'input-group-text');
-        $inputPosition = strrpos($html, '<input');
-        self::assertLessThan($inputPosition, $addonPosition);
+        $this->assertSeeHtmlInOrder($html, [
+            '<div class="input-group-prepend">',
+            '<span class="input-group-text">Test prepend</span>',
+            '<input'
+        ]);
     }
 
     /** @test */
@@ -23,10 +23,10 @@ class InputAddonsTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap5
     {
         config()->set('form-components.floating_label', false);
         $html = $this->renderComponent(Input::class, ['name' => 'first_name', 'append' => 'Test append']);
-        self::assertStringContainsString('<div class="input-group-append">', $html);
-        self::assertStringContainsString('<span class="input-group-text">Test append</span>', $html);
-        $addonPosition = strrpos($html, 'input-group-text');
-        $inputPosition = strrpos($html, '<input');
-        self::assertLessThan($addonPosition, $inputPosition);
+        $this->assertSeeHtmlInOrder($html, [
+            '<input',
+            '<div class="input-group-append">',
+            '<span class="input-group-text">Test append</span>',
+        ]);
     }
 }

--- a/tests/Unit/Bootstrap4/Inputs/Caption/InputCaptionTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/Caption/InputCaptionTest.php
@@ -10,10 +10,9 @@ class InputCaptionTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap
     public function it_can_set_input_caption(): void
     {
         $html = $this->renderComponent(Input::class, ['name' => 'first_name', 'caption' => 'Test caption']);
-        self::assertStringContainsString(' aria-describedby="text-first-name-caption"', $html);
-        self::assertStringContainsString(
-            '<small id="text-first-name-caption" class="form-text text-muted">Test caption</small>',
-            $html
-        );
+        $this->assertSeeHtmlInOrder($html, [
+            ' aria-describedby="text-first-name-caption"',
+            '<small id="text-first-name-caption" class="form-text text-muted">Test caption</small>'
+        ]);
     }
 }

--- a/tests/Unit/Bootstrap4/Inputs/Validation/InputValidationFailureTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/Validation/InputValidationFailureTest.php
@@ -2,7 +2,30 @@
 
 namespace Okipa\LaravelFormComponents\Tests\Unit\Bootstrap4\Inputs\Validation;
 
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\ViewErrorBag;
+use Okipa\LaravelFormComponents\Components\Input;
+
 class InputValidationFailureTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap5\Inputs\Validation\InputValidationFailureTest
 {
-    //
+    /** @test */
+    public function it_can_display_input_file_validation_failure_when_allowed(): void
+    {
+        config()->set('form-components.display_validation_failure', false);
+        $messageBag = app(MessageBag::class)->add('first_name', 'Error test');
+        $errors = app(ViewErrorBag::class)->put('default', $messageBag);
+        session()->put(compact('errors'));
+        $this->executeWebMiddlewareGroup();
+        $html = $this->renderComponent(Input::class, [
+            'type' => 'file',
+            'name' => 'first_name',
+            'displayValidationFailure' => true,
+        ]);
+        $this->assertSeeHtmlInOrder($html, [
+            '<div class="custom-file is-invalid">',
+            '<input',
+            ' class="custom-file-input"',
+            '<div class="invalid-feedback">Error test</div>',
+        ]);
+    }
 }

--- a/tests/Unit/Bootstrap4/Inputs/Validation/InputValidationFailureTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/Validation/InputValidationFailureTest.php
@@ -28,4 +28,50 @@ class InputValidationFailureTest extends \Okipa\LaravelFormComponents\Tests\Unit
             '<div class="invalid-feedback">Error test</div>',
         ]);
     }
+
+    /** @test */
+    public function it_can_display_input_file_validation_failure_with_prepend_addon(): void
+    {
+        config()->set('form-components.display_validation_failure', false);
+        $messageBag = app(MessageBag::class)->add('first_name', 'Error test');
+        $errors = app(ViewErrorBag::class)->put('default', $messageBag);
+        session()->put(compact('errors'));
+        $this->executeWebMiddlewareGroup();
+        $html = $this->renderComponent(Input::class, [
+            'type' => 'file',
+            'name' => 'first_name',
+            'prepend' => 'Test prepend',
+            'displayValidationFailure' => true,
+        ]);
+        $this->assertSeeHtmlInOrder($html, [
+            '<div class="input-group is-invalid">',
+            '<div class="custom-file">',
+            '<input',
+            ' class="custom-file-input"',
+            '<div class="invalid-feedback">Error test</div>',
+        ]);
+    }
+
+    /** @test */
+    public function it_can_display_input_file_validation_failure_with_append_addon(): void
+    {
+        config()->set('form-components.display_validation_failure', false);
+        $messageBag = app(MessageBag::class)->add('first_name', 'Error test');
+        $errors = app(ViewErrorBag::class)->put('default', $messageBag);
+        session()->put(compact('errors'));
+        $this->executeWebMiddlewareGroup();
+        $html = $this->renderComponent(Input::class, [
+            'type' => 'file',
+            'name' => 'first_name',
+            'append' => 'Test append',
+            'displayValidationFailure' => true,
+        ]);
+        $this->assertSeeHtmlInOrder($html, [
+            '<div class="input-group is-invalid">',
+            '<div class="custom-file">',
+            '<input',
+            ' class="custom-file-input"',
+            '<div class="invalid-feedback">Error test</div>',
+        ]);
+    }
 }

--- a/tests/Unit/Bootstrap4/Inputs/Validation/InputValidationSuccessTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/Validation/InputValidationSuccessTest.php
@@ -2,7 +2,29 @@
 
 namespace Okipa\LaravelFormComponents\Tests\Unit\Bootstrap4\Inputs\Validation;
 
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\ViewErrorBag;
+use Okipa\LaravelFormComponents\Components\Input;
+
 class InputValidationSuccessTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap5\Inputs\Validation\InputValidationSuccessTest
 {
-    //
+    /** @test */
+    public function it_can_display_input_file_validation_success_when_allowed(): void
+    {
+        config()->set('form-components.display_validation_success', false);
+        $messageBag = app(MessageBag::class)->add('other_field', 'Error test');
+        $errors = app(ViewErrorBag::class)->put('default', $messageBag);
+        session()->put(compact('errors'));
+        $this->executeWebMiddlewareGroup();
+        $html = $this->renderComponent(Input::class, [
+            'type' => 'file',
+            'name' => 'first_name',
+            'displayValidationSuccess' => true,
+        ]);
+        $this->assertSeeHtmlInOrder($html, [
+            '<div class="custom-file is-valid">',
+            '<input',
+            ' class="custom-file-input"',
+        ]);
+    }
 }

--- a/tests/Unit/Bootstrap4/Inputs/Validation/InputValidationSuccessTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/Validation/InputValidationSuccessTest.php
@@ -9,7 +9,7 @@ use Okipa\LaravelFormComponents\Components\Input;
 class InputValidationSuccessTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap5\Inputs\Validation\InputValidationSuccessTest
 {
     /** @test */
-    public function it_can_display_input_file_validation_success_when_allowed(): void
+    public function it_can_display_input_file_validation_success(): void
     {
         config()->set('form-components.display_validation_success', false);
         $messageBag = app(MessageBag::class)->add('other_field', 'Error test');
@@ -23,6 +23,50 @@ class InputValidationSuccessTest extends \Okipa\LaravelFormComponents\Tests\Unit
         ]);
         $this->assertSeeHtmlInOrder($html, [
             '<div class="custom-file is-valid">',
+            '<input',
+            ' class="custom-file-input"',
+        ]);
+    }
+
+    /** @test */
+    public function it_can_display_input_file_validation_success_with_prepend_addon(): void
+    {
+        config()->set('form-components.display_validation_success', false);
+        $messageBag = app(MessageBag::class)->add('other_field', 'Error test');
+        $errors = app(ViewErrorBag::class)->put('default', $messageBag);
+        session()->put(compact('errors'));
+        $this->executeWebMiddlewareGroup();
+        $html = $this->renderComponent(Input::class, [
+            'type' => 'file',
+            'name' => 'first_name',
+            'prepend' => 'Test prepend',
+            'displayValidationSuccess' => true,
+        ]);
+        $this->assertSeeHtmlInOrder($html, [
+            '<div class="input-group is-valid">',
+            '<div class="custom-file">',
+            '<input',
+            ' class="custom-file-input"',
+        ]);
+    }
+
+    /** @test */
+    public function it_can_display_input_file_validation_success_with_append_addon(): void
+    {
+        config()->set('form-components.display_validation_success', false);
+        $messageBag = app(MessageBag::class)->add('other_field', 'Error test');
+        $errors = app(ViewErrorBag::class)->put('default', $messageBag);
+        session()->put(compact('errors'));
+        $this->executeWebMiddlewareGroup();
+        $html = $this->renderComponent(Input::class, [
+            'type' => 'file',
+            'name' => 'first_name',
+            'append' => 'Test append',
+            'displayValidationSuccess' => true,
+        ]);
+        $this->assertSeeHtmlInOrder($html, [
+            '<div class="input-group is-valid">',
+            '<div class="custom-file">',
             '<input',
             ' class="custom-file-input"',
         ]);

--- a/tests/Unit/Bootstrap5/Inputs/Addons/InputAddonsTest.php
+++ b/tests/Unit/Bootstrap5/Inputs/Addons/InputAddonsTest.php
@@ -25,10 +25,10 @@ class InputAddonsTest extends TestCase
     {
         config()->set('form-components.floating_label', false);
         $html = $this->renderComponent(Input::class, ['name' => 'first_name', 'prepend' => 'Test prepend']);
-        self::assertStringContainsString('<label', $html);
-        $labelPosition = strrpos($html, '<label');
-        $inputGroupPosition = strrpos($html, '<div class="input-group">');
-        self::assertLessThan($inputGroupPosition, $labelPosition);
+        $this->assertSeeHtmlInOrder($html, [
+            '<label',
+            '<div class="input-group">'
+        ]);
     }
 
     /** @test */
@@ -36,10 +36,10 @@ class InputAddonsTest extends TestCase
     {
         config()->set('form-components.floating_label', false);
         $html = $this->renderComponent(Input::class, ['name' => 'first_name', 'append' => 'Test append']);
-        self::assertStringContainsString('<label', $html);
-        $labelPosition = strrpos($html, '<label');
-        $inputGroupPosition = strrpos($html, '<div class="input-group">');
-        self::assertLessThan($inputGroupPosition, $labelPosition);
+        $this->assertSeeHtmlInOrder($html, [
+            '<label',
+            '<div class="input-group">'
+        ]);
     }
 
     /** @test */
@@ -47,10 +47,10 @@ class InputAddonsTest extends TestCase
     {
         config()->set('form-components.floating_label', false);
         $html = $this->renderComponent(Input::class, ['name' => 'first_name', 'prepend' => 'Test prepend']);
-        self::assertStringContainsString('<span class="input-group-text">Test prepend</span>', $html);
-        $addonPosition = strrpos($html, 'input-group-text');
-        $inputPosition = strrpos($html, '<input');
-        self::assertLessThan($inputPosition, $addonPosition);
+        $this->assertSeeHtmlInOrder($html, [
+            '<span class="input-group-text">Test prepend</span>',
+            '<input'
+        ]);
     }
 
     /** @test */
@@ -73,8 +73,10 @@ class InputAddonsTest extends TestCase
             'locales' => ['fr', 'en'],
             'prepend' => fn(string $locale) => 'Test prepend ' . $locale,
         ]);
-        self::assertStringContainsString('Test prepend fr', $html);
-        self::assertStringContainsString('Test prepend en', $html);
+        $this->assertSeeHtmlInOrder($html, [
+            'Test prepend fr',
+            'Test prepend en'
+        ]);
     }
 
     /** @test */
@@ -82,10 +84,10 @@ class InputAddonsTest extends TestCase
     {
         config()->set('form-components.floating_label', false);
         $html = $this->renderComponent(Input::class, ['name' => 'first_name', 'append' => 'Test append']);
-        self::assertStringContainsString('<span class="input-group-text">Test append</span>', $html);
-        $addonPosition = strrpos($html, 'input-group-text');
-        $inputPosition = strrpos($html, '<input');
-        self::assertLessThan($addonPosition, $inputPosition);
+        $this->assertSeeHtmlInOrder($html, [
+            '<input',
+            '<span class="input-group-text">Test append</span>',
+        ]);
     }
 
     /** @test */
@@ -108,7 +110,9 @@ class InputAddonsTest extends TestCase
             'locales' => ['fr', 'en'],
             'append' => fn(string $locale) => 'Test append ' . $locale,
         ]);
-        self::assertStringContainsString('Test append fr', $html);
-        self::assertStringContainsString('Test append en', $html);
+        $this->assertSeeHtmlInOrder($html, [
+            'Test append fr',
+            'Test append en'
+        ]);
     }
 }

--- a/tests/Unit/Bootstrap5/Inputs/Caption/InputCaptionTest.php
+++ b/tests/Unit/Bootstrap5/Inputs/Caption/InputCaptionTest.php
@@ -11,10 +11,9 @@ class InputCaptionTest extends TestCase
     public function it_can_set_input_caption(): void
     {
         $html = $this->renderComponent(Input::class, ['name' => 'first_name', 'caption' => 'Test caption']);
-        self::assertStringContainsString(' aria-describedby="text-first-name-caption"', $html);
-        self::assertStringContainsString(
+        $this->assertSeeHtmlInOrder($html, [
+            ' aria-describedby="text-first-name-caption"',
             '<div id="text-first-name-caption" class="form-text">Test caption</div>',
-            $html
-        );
+        ]);
     }
 }

--- a/tests/Unit/Bootstrap5/Inputs/Validation/InputValidationFailureTest.php
+++ b/tests/Unit/Bootstrap5/Inputs/Validation/InputValidationFailureTest.php
@@ -32,8 +32,11 @@ class InputValidationFailureTest extends TestCase
             'name' => 'first_name',
             'displayValidationFailure' => true,
         ]);
-        self::assertStringContainsString(' is-invalid', $html);
-        self::assertStringContainsString('<div class="invalid-feedback">Error test</div>', $html);
+        $this->assertSeeHtmlInOrder($html, [
+            '<input',
+            ' class="form-control is-invalid"',
+            '<div class="invalid-feedback">Error test</div>',
+        ]);
     }
 
     /** @test */
@@ -49,15 +52,16 @@ class InputValidationFailureTest extends TestCase
             'displayValidationFailure' => true,
             'locales' => ['fr', 'en'],
         ]);
-        self::assertEquals(2, substr_count($html, ' is-invalid'));
-        self::assertStringContainsString(
+        $this->assertSeeHtmlInOrder($html, [
+            '<input',
+            ' class="',
+            ' is-invalid',
             '<div class="invalid-feedback">Test validation.attributes.first_name (FR) error message.</div>',
-            $html
-        );
-        self::assertStringContainsString(
+            '<input',
+            ' class="',
+            ' is-invalid',
             '<div class="invalid-feedback">Test validation.attributes.first_name (EN) error message.</div>',
-            $html
-        );
+        ]);
     }
 
     /** @test */
@@ -72,8 +76,10 @@ class InputValidationFailureTest extends TestCase
             'name' => 'first_name',
             'displayValidationFailure' => false,
         ]);
-        self::assertStringNotContainsString('is-invalid', $html);
-        self::assertStringNotContainsString('<div class="invalid-feedback">Error test</div>', $html);
+        $this->assertDontSeeHtml($html, [
+            'is-invalid',
+            '<div class="invalid-feedback">Error test</div>',
+        ]);
     }
 
     /** @test */
@@ -88,8 +94,12 @@ class InputValidationFailureTest extends TestCase
             'name' => 'first_name[0]',
             'displayValidationFailure' => true,
         ]);
-        self::assertStringContainsString(' is-invalid', $html);
-        self::assertStringContainsString('<div class="invalid-feedback">Error test</div>', $html);
+        $this->assertSeeHtmlInOrder($html, [
+            '<input',
+            ' class="',
+            ' is-invalid',
+            '<div class="invalid-feedback">Error test</div>',
+        ]);
     }
 
     /** @test */
@@ -105,7 +115,11 @@ class InputValidationFailureTest extends TestCase
             'displayValidationFailure' => true,
             'errorBag' => 'test_error_bag',
         ]);
-        self::assertStringContainsString(' is-invalid', $html);
-        self::assertStringContainsString('<div class="invalid-feedback">Error test</div>', $html);
+        $this->assertSeeHtmlInOrder($html, [
+            '<input',
+            ' class="',
+            ' is-invalid',
+            '<div class="invalid-feedback">Error test</div>',
+        ]);
     }
 }

--- a/tests/Unit/Bootstrap5/Inputs/Validation/InputValidationSuccessTest.php
+++ b/tests/Unit/Bootstrap5/Inputs/Validation/InputValidationSuccessTest.php
@@ -32,7 +32,10 @@ class InputValidationSuccessTest extends TestCase
             'name' => 'first_name',
             'displayValidationSuccess' => true,
         ]);
-        self::assertStringContainsString(' is-valid', $html);
+        $this->assertSeeHtmlInOrder($html, [
+            '<input',
+            ' class="form-control is-valid"',
+        ]);
     }
 
     /** @test */
@@ -47,6 +50,6 @@ class InputValidationSuccessTest extends TestCase
             'name' => 'first_name',
             'displayValidationSuccess' => false,
         ]);
-        self::assertStringNotContainsString('is-valid', $html);
+        $this->assertDontSeeHtml($html, ['is-valid']);
     }
 }


### PR DESCRIPTION
* Fixed Bootstrap 4 input file input validation class wrong positioning:
  * `is-valid` and `is-invalid` classes are now added to the `custom-file` div without addon declaration
  * `is-valid` and `is-invalid` classes are now added to the `input-group` div with addon declaration
* Fixed Bootstrap 4 input caption and error message positioning: they are now positioned under input group div in order to be displayed correctly