### PR TITLE
Fix bs4 checkbox & radio classes

### DIFF
--- a/resources/views/bootstrap-4/checkbox.blade.php
+++ b/resources/views/bootstrap-4/checkbox.blade.php
@@ -20,17 +20,17 @@
         $label = $groupMode ? $groupLabel : $getLabel();
         $checked = $groupMode ? $getGroupModeCheckedStatus($groupValue) : $getSingleModeCheckedStatus();
     @endphp
-    <div @class(['form-check', 'form-check-inline' => $inline, 'mb-3' => $groupMode ? null : $marginBottom])>
+    <div @class(['custom-control', 'custom-checkbox', 'custom-control-inline' => $inline, 'mb-3' => $groupMode ? null : $marginBottom])>
         <input {{ $attributes->merge([
             'wire:model' . $getComponentLivewireModifier() => $isWired && ! $hasComponentNativeLivewireModelBinding() ? $name : null,
             'id' => $id,
-            'class' => 'form-check-input' . ($validationClass ? ' ' . $validationClass : null),
+            'class' => 'custom-control-input' . ($validationClass ? ' ' . $validationClass : null),
             'name' => $name . ($groupMode ? '[]' : null),
             'value' => $groupMode ? $groupValue : null,
             'checked' => $isWired ? null : $checked,
             'aria-describedby' => $caption ? ($groupMode && $caption ? $captionId : $id) . '-caption' : null,
         ]) }} type="checkbox">
-        <x-form::partials.label :id="$id" class="form-check-label" :label="$label"/>
+        <x-form::partials.label :id="$id" class="custom-control-label" :label="$label"/>
         @if(! $groupMode)
             <x-form::partials.caption :inputId="$id" :caption="$caption"/>
             <x-form::partials.error-message :message="$errorMessage"/>

--- a/resources/views/bootstrap-4/radio.blade.php
+++ b/resources/views/bootstrap-4/radio.blade.php
@@ -13,17 +13,17 @@
             $radioId = $getId(suffix: $groupValue) ?: $getDefaultId(prefix: 'radio', suffix: $groupValue);
             $checked = $getGroupModeCheckedStatus($groupValue);
         @endphp
-        <div @class(['form-check', 'form-check-inline' => $inline])>
+        <div @class(['custom-control', 'custom-radio', 'custom-control-inline' => $inline])>
             <input {{ $attributes->merge([
                 'wire:model' . $getComponentLivewireModifier() => $isWired && ! $hasComponentNativeLivewireModelBinding() ? $name : null,
                 'id' => $radioId,
-                'class' => 'form-check-input',
+                'class' => 'custom-control-input',
                 'name' => $name,
                 'value' => $groupValue,
                 'checked' => $isWired ? null : $checked,
                 'aria-describedby' => $caption ? $captionId . '-caption' : null,
             ]) }} type="radio">
-            <x:form::partials.label :id="$radioId" class="form-check-label" :label="$groupLabel"/>
+            <x:form::partials.label :id="$radioId" class="custom-control-label" :label="$groupLabel"/>
         </div>
     @endforeach
     <x:form::partials.caption :inputId="$captionId" :caption="$caption"/>

--- a/tests/Unit/Bootstrap4/Inputs/Inline/CheckboxInlineTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/Inline/CheckboxInlineTest.php
@@ -10,7 +10,7 @@ class CheckboxInlineTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstr
     public function it_can_set_checkbox_stacked_mode_by_default(): void
     {
         $html = $this->renderComponent(Checkbox::class, ['name' => 'active']);
-        self::assertStringNotContainsString('class="form-check form-check-inline', $html);
+        self::assertStringNotContainsString('class="custom-control custom-checkbox custom-control-inline', $html);
     }
 
     /** @test */
@@ -25,14 +25,14 @@ class CheckboxInlineTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstr
                 'livewire' => 'Livewire',
             ],
         ]);
-        self::assertStringNotContainsString('class="form-check form-check-inline', $html);
+        self::assertStringNotContainsString('class="custom-control custom-checkbox custom-control-inline', $html);
     }
 
     /** @test */
     public function it_can_set_checkbox_inlined_mode(): void
     {
         $html = $this->renderComponent(Checkbox::class, ['name' => 'active', 'inline' => true]);
-        self::assertStringContainsString(' class="form-check form-check-inline', $html);
+        self::assertStringContainsString(' class="custom-control custom-checkbox custom-control-inline', $html);
     }
 
     /** @test */
@@ -48,6 +48,6 @@ class CheckboxInlineTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstr
             ],
             'inline' => true,
         ]);
-        self::assertEquals(4, substr_count($html, ' class="form-check form-check-inline'));
+        self::assertEquals(4, substr_count($html, ' class="custom-control custom-checkbox custom-control-inline'));
     }
 }

--- a/tests/Unit/Bootstrap4/Inputs/Inline/RadioInlineTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/Inline/RadioInlineTest.php
@@ -13,7 +13,7 @@ class RadioInlineTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap5
             'name' => 'gender',
             'group' => [1 => 'Male', 2 => 'Female'],
         ]);
-        self::assertStringNotContainsString('class="form-check form-check-inline', $html);
+        self::assertStringNotContainsString('class="custom-control custom-radio custom-control-inline', $html);
     }
 
     /** @test */
@@ -24,6 +24,6 @@ class RadioInlineTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap5
             'group' => [1 => 'Male', 2 => 'Female'],
             'inline' => true,
         ]);
-        self::assertEquals(2, substr_count($html, ' class="form-check form-check-inline'));
+        self::assertEquals(2, substr_count($html, ' class="custom-control custom-radio custom-control-inline'));
     }
 }

--- a/tests/Unit/Bootstrap4/Inputs/Input/CheckboxInputTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/Input/CheckboxInputTest.php
@@ -2,7 +2,16 @@
 
 namespace Okipa\LaravelFormComponents\Tests\Unit\Bootstrap4\Inputs\Input;
 
-class CheckboxInputTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap5\Inputs\Input\CheckboxInputTest
+use Okipa\LaravelFormComponents\Components\Checkbox;
+use Okipa\LaravelFormComponents\Tests\TestCase;
+
+class CheckboxInputTest extends TestCase
 {
-    //
+    /** @test */
+    public function it_can_set_checkbox_input_class(): void
+    {
+        $html = $this->renderComponent(Checkbox::class, ['name' => 'active']);
+        self::assertStringContainsString('<div class="custom-control custom-checkbox', $html);
+        self::assertStringContainsString('<input id="checkbox-active" class="custom-control-input"', $html);
+    }
 }

--- a/tests/Unit/Bootstrap4/Inputs/Input/RadioInputTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/Input/RadioInputTest.php
@@ -2,7 +2,20 @@
 
 namespace Okipa\LaravelFormComponents\Tests\Unit\Bootstrap4\Inputs\Input;
 
-class RadioInputTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap5\Inputs\Input\RadioInputTest
+use Okipa\LaravelFormComponents\Components\Radio;
+use Okipa\LaravelFormComponents\Tests\TestCase;
+
+class RadioInputTest extends TestCase
 {
-    //
+    /** @test */
+    public function it_can_set_radio_input_class(): void
+    {
+        $html = $this->renderComponent(Radio::class, [
+            'name' => 'gender',
+            'group' => ['female' => 'Female', 'male' => 'Male'],
+        ]);
+        self::assertStringContainsString('<div class="custom-control custom-radio', $html);
+        self::assertStringContainsString('<input id="radio-gender-female" class="custom-control-input"', $html);
+        self::assertStringContainsString('<input id="radio-gender-male" class="custom-control-input"', $html);
+    }
 }

--- a/tests/Unit/Bootstrap4/Inputs/Label/CheckboxLabelTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/Label/CheckboxLabelTest.php
@@ -6,7 +6,6 @@ use Okipa\LaravelFormComponents\Components\Checkbox;
 
 class CheckboxLabelTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap5\Inputs\Label\CheckboxLabelTest
 {
-
     /** @test */
     public function it_can_setup_checkbox_default_label_when_none_is_defined(): void
     {
@@ -27,6 +26,7 @@ class CheckboxLabelTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstra
         $html = $this->renderComponent(Checkbox::class, ['name' => 'active', 'label' => 'Test label']);
         self::assertStringContainsString(' class="custom-control-label">Test label</label>', $html);
     }
+
     /** @test */
     public function it_can_set_checkboxes_labels_in_group_mode(): void
     {

--- a/tests/Unit/Bootstrap4/Inputs/Label/CheckboxLabelTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/Label/CheckboxLabelTest.php
@@ -2,7 +2,46 @@
 
 namespace Okipa\LaravelFormComponents\Tests\Unit\Bootstrap4\Inputs\Label;
 
+use Okipa\LaravelFormComponents\Components\Checkbox;
+
 class CheckboxLabelTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap5\Inputs\Label\CheckboxLabelTest
 {
-    //
+
+    /** @test */
+    public function it_can_setup_checkbox_default_label_when_none_is_defined(): void
+    {
+        $html = $this->renderComponent(Checkbox::class, ['name' => 'active']);
+        self::assertStringContainsString(' class="custom-control-label">validation.attributes.active</label>', $html);
+    }
+
+    /** @test */
+    public function it_can_setup_checkbox_default_label_with_array_name_when_none_is_defined(): void
+    {
+        $html = $this->renderComponent(Checkbox::class, ['name' => 'active[0]']);
+        self::assertStringContainsString(' class="custom-control-label">validation.attributes.active</label>', $html);
+    }
+
+    /** @test */
+    public function it_can_set_checkbox_label(): void
+    {
+        $html = $this->renderComponent(Checkbox::class, ['name' => 'active', 'label' => 'Test label']);
+        self::assertStringContainsString(' class="custom-control-label">Test label</label>', $html);
+    }
+    /** @test */
+    public function it_can_set_checkboxes_labels_in_group_mode(): void
+    {
+        $html = $this->renderComponent(Checkbox::class, [
+            'name' => 'technologies',
+            'group' => [
+                'laravel' => 'Laravel',
+                'bootstrap' => 'Bootstrap',
+                'tailwind' => 'Tailwind',
+                'livewire' => 'Livewire',
+            ],
+        ]);
+        self::assertStringContainsString(' class="custom-control-label">Laravel</label>', $html);
+        self::assertStringContainsString(' class="custom-control-label">Bootstrap</label>', $html);
+        self::assertStringContainsString(' class="custom-control-label">Tailwind</label>', $html);
+        self::assertStringContainsString(' class="custom-control-label">Livewire</label>', $html);
+    }
 }

--- a/tests/Unit/Bootstrap4/Inputs/Label/RadioLabelTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/Label/RadioLabelTest.php
@@ -2,7 +2,18 @@
 
 namespace Okipa\LaravelFormComponents\Tests\Unit\Bootstrap4\Inputs\Label;
 
+use Okipa\LaravelFormComponents\Components\Radio;
+
 class RadioLabelTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap5\Inputs\Label\RadioLabelTest
 {
-    //
+    /** @test */
+    public function it_can_set_radio_labels_in_group_mode(): void
+    {
+        $html = $this->renderComponent(Radio::class, [
+            'name' => 'gender',
+            'group' => ['female' => 'Female', 'male' => 'Male'],
+        ]);
+        self::assertStringContainsString(' class="custom-control-label">Male</label>', $html);
+        self::assertStringContainsString(' class="custom-control-label">Female</label>', $html);
+    }
 }

--- a/tests/Unit/Bootstrap4/Inputs/MarginBottom/CheckboxMarginBottomTest.php
+++ b/tests/Unit/Bootstrap4/Inputs/MarginBottom/CheckboxMarginBottomTest.php
@@ -2,7 +2,14 @@
 
 namespace Okipa\LaravelFormComponents\Tests\Unit\Bootstrap4\Inputs\MarginBottom;
 
+use Okipa\LaravelFormComponents\Components\Checkbox;
+
 class CheckboxMarginBottomTest extends \Okipa\LaravelFormComponents\Tests\Unit\Bootstrap5\Inputs\MarginBottom\CheckboxMarginBottomTest
 {
-    //
+    /** @test */
+    public function it_can_enable_checkbox_margin_bottom_by_default(): void
+    {
+        $html = $this->renderComponent(Checkbox::class, ['name' => 'active']);
+        self::assertStringContainsString('<div class="custom-control custom-checkbox mb-3">', $html);
+    }
 }


### PR DESCRIPTION
When we use bootstrap-4 theme, classes for radio & checkbox templates are not bootstrap 4 classes.  
Actually, these template use bootstrap 5 classes.